### PR TITLE
Fix JOIN THE ACTION section height on mobile

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -952,8 +952,17 @@ body::before {
     padding: 1px;
     margin: 0;
     border-radius: 16px;
-    min-height: calc(100vh - 2px);
     position: relative;
+  }
+
+  /* Full height only for game tables, not form sections */
+  .neo-table.game-table {
+    min-height: calc(100vh - 2px);
+  }
+
+  /* Form sections should have reasonable padding */
+  .neo-table:not(.game-table) {
+    padding: 20px;
   }
 
   /* Priority 1: Pot display - most important info */

--- a/lib/poker_server_web/live/game_live/show.ex
+++ b/lib/poker_server_web/live/game_live/show.ex
@@ -220,7 +220,7 @@ defmodule PokerServerWeb.GameLive.Show do
     ~H"""
     <div class="max-w-none mx-0 relative px-0 sm:max-w-6xl sm:mx-auto sm:px-4">
       <!-- Neo Wave Game Interface -->
-      <div :if={@player_view} class="mt-0 neo-table relative overflow-hidden">
+      <div :if={@player_view} class="mt-0 neo-table game-table relative overflow-hidden">
         <!-- Floating particle effects -->
         <div class="neo-particles">
           <div class="neo-particle" style="left: 10%; animation-delay: 0s;"></div>


### PR DESCRIPTION
- Remove min-height from general .neo-table class that was causing form sections to be too tall
- Add specific .game-table class for actual game tables that need full viewport height
- Apply reasonable padding (20px) to form sections on mobile
- Maintain rainbow border styling while fixing height issue

🤖 Generated with [Claude Code](https://claude.ai/code)